### PR TITLE
add config file support

### DIFF
--- a/cmd/grpc-client-cli/appflags.go
+++ b/cmd/grpc-client-cli/appflags.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+	"github.com/vadimi/grpc-client-cli/internal/cliext"
+)
+
+const flagConfigFile = "config"
+
+func appFlags() []cli.Flag {
+	return []cli.Flag{
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:    "service",
+				Aliases: []string{"s"},
+				Value:   "",
+				Usage:   "grpc full or partial service name",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:    "method",
+				Aliases: []string{"m"},
+				Value:   "",
+				Usage:   "grpc service method name",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:    "input",
+				Aliases: []string{"i"},
+				Value:   "",
+				Usage:   "file that contains message json, it will be ignored if used in conjunction with stdin pipes",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:    "deadline",
+				Aliases: []string{"d"},
+				Value:   "15s",
+				Usage:   "grpc call deadline in go duration format, e.g. 15s, 3m, 1h, etc. If no format is specified, defaults to seconds",
+			}),
+		altsrc.NewBoolFlag(
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"V"},
+				Usage:   "output some additional information like request time and message size",
+			}),
+		altsrc.NewBoolFlag(
+			&cli.BoolFlag{
+				Name:  "tls",
+				Value: false,
+				Usage: "use TLS when connecting to grpc server",
+			}),
+		altsrc.NewBoolFlag(
+			&cli.BoolFlag{
+				Name:  "insecure",
+				Value: false,
+				Usage: "skip server's certificate chain and host name verification, this option should only be used for testing",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:  "cacert",
+				Value: "",
+				Usage: "the CA certificate file for verifying the server, this certificate is ignored if --insecure option is true",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:  "cert",
+				Value: "",
+				Usage: "client certificate to present to the server, only valid with -certkey option",
+			}),
+		altsrc.NewStringFlag(
+			&cli.StringFlag{
+				Name:  "certkey",
+				Value: "",
+				Usage: "client private key, only valid with -cert option",
+			}),
+		altsrc.NewStringSliceFlag(
+			&cli.StringSliceFlag{
+				Name:     "proto",
+				Required: false,
+				Usage: "proto files or directories to search for proto files, " +
+					"if this option is provided service reflection would be ignored. " +
+					"In order to provide multiple paths, separate them with comma",
+			}),
+		altsrc.NewStringSliceFlag(
+			&cli.StringSliceFlag{
+				Name:     "protoimports",
+				Required: false,
+				Usage:    "additional directories to search for dependencies, should be used with --proto option",
+			}),
+		altsrc.NewGenericFlag(
+			&cli.GenericFlag{
+				Name:        "header",
+				Aliases:     []string{"H"},
+				Required:    false,
+				Value:       cliext.NewMapValue(),
+				Usage:       "extra header(s) to include in the request",
+				DefaultText: "no extra headers",
+			}),
+		&cli.StringFlag{
+			Name:  "authority",
+			Value: "",
+			Usage: "override :authority header",
+		},
+		&cli.GenericFlag{
+			Name:    "informat",
+			Aliases: []string{"if"},
+			Value: &cliext.EnumValue{
+				Enum:    []string{"json", "text"},
+				Default: "json",
+			},
+			Usage: "input proto message format, supported values are json and text",
+		},
+		&cli.GenericFlag{
+			Name:    "outformat",
+			Aliases: []string{"of"},
+			Value: &cliext.EnumValue{
+				Enum:    []string{"json", "text"},
+				Default: "json",
+			},
+			Usage: "output proto message format, supported values are json and text",
+		},
+		altsrc.NewBoolFlag(
+			&cli.BoolFlag{
+				Name:  "keepalive",
+				Value: false,
+				Usage: "If true, send keepalive pings even with no active RPCs. If false, default grpc settings are used",
+			}),
+		altsrc.NewDurationFlag(
+			&cli.DurationFlag{
+				Name:        "keepalive-time",
+				Usage:       `If set, send keepalive pings every "keepalive-time" timeout. If not set, default grpc settings are used`,
+				DefaultText: "not set",
+			}),
+		altsrc.NewIntFlag(
+			&cli.IntFlag{
+				Name:    "max-receive-message-size",
+				Aliases: []string{"mrms", "max-recv-msg-size"},
+				Value:   0,
+				Usage:   "If greater than 0, sets the max receive message size to bytes, else uses grpc defaults (currently 4 MB)",
+			}),
+		&cli.StringFlag{
+			Name:  flagConfigFile,
+			Usage: "config file in yaml format to configure the cli parameters, the default location is ~/.grpc-client-cli.yaml",
+		},
+	}
+}

--- a/cmd/grpc-client-cli/main.go
+++ b/cmd/grpc-client-cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
@@ -20,123 +21,8 @@ func main() {
 	app.Usage = "generic gRPC client"
 	app.Version = appVersion
 	app.EnableBashCompletion = true
-
-	app.Flags = []cli.Flag{
-		&cli.StringFlag{
-			Name:    "service",
-			Aliases: []string{"s"},
-			Value:   "",
-			Usage:   "grpc full or partial service name",
-		},
-		&cli.StringFlag{
-			Name:    "method",
-			Aliases: []string{"m"},
-			Value:   "",
-			Usage:   "grpc service method name",
-		},
-		&cli.StringFlag{
-			Name:    "input",
-			Aliases: []string{"i"},
-			Value:   "",
-			Usage:   "file that contains message json, it will be ignored if used in conjunction with stdin pipes",
-		},
-		&cli.StringFlag{
-			Name:    "deadline",
-			Aliases: []string{"d"},
-			Value:   "15s",
-			Usage:   "grpc call deadline in go duration format, e.g. 15s, 3m, 1h, etc. If no format is specified, defaults to seconds",
-		},
-		&cli.BoolFlag{
-			Name:    "verbose",
-			Aliases: []string{"V"},
-			Usage:   "output some additional information like request time and message size",
-		},
-		&cli.BoolFlag{
-			Name:  "tls",
-			Value: false,
-			Usage: "use TLS when connecting to grpc server",
-		},
-		&cli.BoolFlag{
-			Name:  "insecure",
-			Value: false,
-			Usage: "skip server's certificate chain and host name verification, this option should only be used for testing",
-		},
-		&cli.StringFlag{
-			Name:  "cacert",
-			Value: "",
-			Usage: "the CA certificate file for verifying the server, this certificate is ignored if --insecure option is true",
-		},
-		&cli.StringFlag{
-			Name:  "cert",
-			Value: "",
-			Usage: "client certificate to present to the server, only valid with -certkey option",
-		},
-		&cli.StringFlag{
-			Name:  "certkey",
-			Value: "",
-			Usage: "client private key, only valid with -cert option",
-		},
-		&cli.StringSliceFlag{
-			Name:     "proto",
-			Required: false,
-			Usage: "proto files or directories to search for proto files, " +
-				"if this option is provided service reflection would be ignored. " +
-				"In order to provide multiple paths, separate them with comma",
-		},
-		&cli.StringSliceFlag{
-			Name:     "protoimports",
-			Required: false,
-			Usage:    "additional directories to search for dependencies, should be used with --proto option",
-		},
-		&cli.GenericFlag{
-			Name:        "header",
-			Aliases:     []string{"H"},
-			Required:    false,
-			Value:       cliext.NewMapValue(),
-			Usage:       "extra header(s) to include in the request",
-			DefaultText: "no extra headers",
-		},
-		&cli.StringFlag{
-			Name:  "authority",
-			Value: "",
-			Usage: "override :authority header",
-		},
-		&cli.GenericFlag{
-			Name:    "informat",
-			Aliases: []string{"if"},
-			Value: &cliext.EnumValue{
-				Enum:    []string{"json", "text"},
-				Default: "json",
-			},
-			Usage: "input proto message format, supported values are json and text",
-		},
-		&cli.GenericFlag{
-			Name:    "outformat",
-			Aliases: []string{"of"},
-			Value: &cliext.EnumValue{
-				Enum:    []string{"json", "text"},
-				Default: "json",
-			},
-			Usage: "output proto message format, supported values are json and text",
-		},
-		&cli.BoolFlag{
-			Name:  "keepalive",
-			Value: false,
-			Usage: "If true, send keepalive pings even with no active RPCs. If false, default grpc settings are used",
-		},
-		&cli.DurationFlag{
-			Name:        "keepalive-time",
-			Usage:       `If set, send keepalive pings every "keepalive-time" timeout. If not set, default grpc settings are used`,
-			DefaultText: "not set",
-		},
-		&cli.IntFlag{
-			Name:    "max-receive-message-size",
-			Aliases: []string{"mrms", "max-recv-msg-size"},
-			Value:   0,
-			Usage:   "If greater than 0, sets the max receive message size to bytes, else uses grpc defaults (currently 4 MB)",
-		},
-	}
-
+	app.Flags = appFlags()
+	app.Before = cliext.InitWithYamlSource(app.Flags, cliext.WithFlagFileName(flagConfigFile))
 	app.Action = baseCmd
 	app.Commands = []*cli.Command{
 		{
@@ -150,7 +36,11 @@ func main() {
 			Action: healthCmd,
 		},
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 func discoverCmd(c *cli.Context) (e error) {

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ require (
 	google.golang.org/grpc v1.44.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/AlecAivazis/survey/v2 v2.3.2 h1:TqTB+aDDCLYhf9/bD2TwSO8u8jDSmMUd2SUVO
 github.com/AlecAivazis/survey/v2 v2.3.2/go.mod h1:TH2kPCDU3Kqq7pLbnCWwZXDBjnhZtmsCle5EiYDJ2fg=
 github.com/ArthurHlt/go-eureka-client v1.1.0 h1:/DDFNFnuTDKYe5EmtYelwY4cen4/x4VGcNFlPsc1lok=
 github.com/ArthurHlt/go-eureka-client v1.1.0/go.mod h1:p5lb6TsmZkMgIAEVpeWefmTeyYXKiN97DkOJrBPKd+8=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
@@ -214,6 +215,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/cliext/yamlconf.go
+++ b/internal/cliext/yamlconf.go
@@ -1,0 +1,143 @@
+package cliext
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+	"gopkg.in/yaml.v2"
+)
+
+type yamlSourceOptions struct {
+	flagFileName string
+	fsys         fs.FS
+}
+
+type SourceOption func(*yamlSourceOptions)
+
+func WithFlagFileName(flagFileName string) SourceOption {
+	return func(o *yamlSourceOptions) {
+		o.flagFileName = flagFileName
+	}
+}
+
+// WithFS is useful in unit testing
+func WithFS(fsys fs.FS) SourceOption {
+	return func(o *yamlSourceOptions) {
+		o.fsys = fsys
+	}
+}
+
+func InitWithYamlSource(flags []cli.Flag, opts ...SourceOption) cli.BeforeFunc {
+	return func(context *cli.Context) error {
+		sourceOptions := &yamlSourceOptions{
+			fsys: os.DirFS("/"),
+		}
+
+		for _, o := range opts {
+			o(sourceOptions)
+		}
+
+		inputSource, err := newYamlSourceFromFlagFunc(sourceOptions)(context)
+		if err != nil {
+			return err
+		}
+
+		return altsrc.ApplyInputSourceValues(context, inputSource, flags)
+	}
+}
+
+func newYamlSourceFromFlagFunc(opts *yamlSourceOptions) func(context *cli.Context) (altsrc.InputSourceContext, error) {
+	return func(context *cli.Context) (altsrc.InputSourceContext, error) {
+		filePath := ""
+		fileRequired := false
+		if context.IsSet(opts.flagFileName) {
+			filePath = context.String(opts.flagFileName)
+			// if config file is passed via parameters, then it's required
+			fileRequired = true
+		}
+
+		return newYamlSourceFromFile(opts.fsys, filePath, fileRequired)
+	}
+}
+
+func newYamlSourceFromFile(fsys fs.FS, file string, fileRequired bool) (altsrc.InputSourceContext, error) {
+	results := map[interface{}]interface{}{}
+	err := readConfigYaml(fsys, file, fileRequired, &results)
+	if err != nil {
+		return nil, err
+	}
+	return altsrc.NewMapInputSource(file, results), nil
+}
+
+func readConfigYaml(fsys fs.FS, filePath string, fileRequired bool, container interface{}) error {
+	configPath, found, err := findConfigFile(fsys, filePath)
+	if err != nil {
+		return fmt.Errorf("cannot find config file: %w", err)
+	}
+	if !found {
+		if fileRequired {
+			return fmt.Errorf("config file %s not found", filePath)
+		}
+		return nil
+	}
+
+	b, err := fs.ReadFile(fsys, configPath)
+	if err != nil {
+		return fmt.Errorf("cannot read config file: %w", err)
+	}
+
+	err = yaml.Unmarshal(b, container)
+	if err != nil {
+		return fmt.Errorf("invalid config file format: %w", err)
+	}
+
+	return nil
+}
+
+func findConfigFile(fsys fs.FS, filePath string) (string, bool, error) {
+	if filePath == "" {
+		return findDefaultConfigFile(fsys)
+	}
+
+	if _, err := fs.Stat(fsys, filePath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return filePath, true, nil
+}
+
+// homeDir config is optional
+func findDefaultConfigFile(fsys fs.FS) (string, bool, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", false, err
+	}
+	homeDir, err = filepath.Rel("/", homeDir)
+	if err != nil {
+		return "", false, err
+	}
+
+	defaultLocations := []string{
+		path.Join(homeDir, ".grpc-client-cli.yaml"),
+		path.Join(homeDir, ".grpc-client-cli.yml"),
+	}
+
+	for _, loc := range defaultLocations {
+		if _, err := fs.Stat(fsys, loc); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", false, err
+		}
+		return loc, true, nil
+	}
+
+	return "", false, nil
+}

--- a/internal/cliext/yamlconf_test.go
+++ b/internal/cliext/yamlconf_test.go
@@ -1,0 +1,117 @@
+package cliext
+
+import (
+	"flag"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+)
+
+var testFlags = []cli.Flag{
+	altsrc.NewIntFlag(&cli.IntFlag{Name: "id", Required: false}),
+	&cli.StringFlag{Name: "config"},
+}
+
+func TestNoConfigFileFound(t *testing.T) {
+	app, set := newTestApp([]string{"test-cmd"})
+
+	fsys := fstest.MapFS{}
+
+	c := cli.NewContext(app, set, nil)
+	command := &cli.Command{
+		Name:  "test-cmd",
+		Flags: testFlags,
+		Action: func(c *cli.Context) error {
+			return nil
+		},
+		Before: InitWithYamlSource(testFlags, WithFlagFileName("config"), WithFS(fsys)),
+	}
+
+	err := command.Run(c)
+	assert.NoError(t, err)
+}
+
+func TestConfigFileRequired(t *testing.T) {
+	app, set := newTestApp([]string{"test-cmd", "--config", "test.yaml"})
+
+	fsys := fstest.MapFS{}
+
+	c := cli.NewContext(app, set, nil)
+	command := &cli.Command{
+		Name:  "test-cmd",
+		Flags: testFlags,
+		Action: func(c *cli.Context) error {
+			return nil
+		},
+		Before: InitWithYamlSource(testFlags, WithFlagFileName("config"), WithFS(fsys)),
+	}
+
+	err := command.Run(c)
+	assert.Error(t, err)
+}
+
+func TestConfigFileLoaded(t *testing.T) {
+	app, set := newTestApp([]string{"test-cmd", "--config", "test.yaml"})
+
+	fsys := fstest.MapFS{
+		"test.yaml": &fstest.MapFile{
+			Data: []byte(`id: 2`),
+		},
+	}
+
+	c := cli.NewContext(app, set, nil)
+	command := &cli.Command{
+		Name:  "test-cmd",
+		Flags: testFlags,
+		Action: func(c *cli.Context) error {
+			require.Equal(t, 2, c.Int("id"))
+			return nil
+		},
+		Before: InitWithYamlSource(testFlags, WithFlagFileName("config"), WithFS(fsys)),
+	}
+
+	err := command.Run(c)
+	assert.NoError(t, err)
+}
+
+func TestDefaultConfigFileLoaded(t *testing.T) {
+	app, set := newTestApp([]string{"test-cmd"})
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	homeDir = strings.Trim(homeDir, "/")
+
+	fsys := fstest.MapFS{
+		path.Join(homeDir, ".grpc-client-cli.yaml"): &fstest.MapFile{
+			Data: []byte(`id: 1`),
+		},
+	}
+
+	c := cli.NewContext(app, set, nil)
+	command := &cli.Command{
+		Name:  "test-cmd",
+		Flags: testFlags,
+		Action: func(c *cli.Context) error {
+			require.Equal(t, 1, c.Int("id"))
+			return nil
+		},
+		Before: InitWithYamlSource(testFlags, WithFlagFileName("config"), WithFS(fsys)),
+	}
+
+	err = command.Run(c)
+	assert.NoError(t, err)
+}
+
+func newTestApp(commandArgs []string) (*cli.App, *flag.FlagSet) {
+	app := &cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	_ = set.Parse(commandArgs)
+	return app, set
+}


### PR DESCRIPTION
load an optional yaml file from ~/.grpc-client-cli.{yaml,yml} or through
--config parameter (required in this case)
not all parameters can be configured through the yaml file