### PR TITLE
support camelCasing in the output

### DIFF
--- a/cmd/grpc-client-cli/app.go
+++ b/cmd/grpc-client-cli/app.go
@@ -43,6 +43,7 @@ type startOpts struct {
 	Authority     string
 	InFormat      caller.MsgFormat
 	OutFormat     caller.MsgFormat
+	OutJsonNames  bool
 
 	// connection credentials
 	TLS      bool
@@ -245,7 +246,7 @@ func (a *app) callService(method *desc.MethodDescriptor, message []byte) error {
 
 // callClientStream calls unary or client stream method
 func (a *app) callClientStream(ctx context.Context, method *desc.MethodDescriptor, messageJSON [][]byte) error {
-	serviceCaller := caller.NewServiceCaller(a.connFact, a.opts.InFormat, a.opts.OutFormat, a.fdescCache)
+	serviceCaller := caller.NewServiceCaller(a.connFact, a.opts.InFormat, a.opts.OutFormat, a.fdescCache, a.opts.OutJsonNames)
 
 	result, err := serviceCaller.CallClientStream(ctx, a.opts.Target, method, messageJSON, grpc.WaitForReady(true))
 	if err != nil {
@@ -264,7 +265,7 @@ func (a *app) printResult(r []byte) {
 
 // callStream calls both server or bi-directional stream methods
 func (a *app) callStream(ctx context.Context, method *desc.MethodDescriptor, messageJSON [][]byte) error {
-	serviceCaller := caller.NewServiceCaller(a.connFact, a.opts.InFormat, a.opts.OutFormat, a.fdescCache)
+	serviceCaller := caller.NewServiceCaller(a.connFact, a.opts.InFormat, a.opts.OutFormat, a.fdescCache, a.opts.OutJsonNames)
 	result, errChan := serviceCaller.CallStream(ctx, a.opts.Target, method, messageJSON, grpc.WaitForReady(true))
 
 	a.printer.BeginArray()

--- a/cmd/grpc-client-cli/app_test.go
+++ b/cmd/grpc-client-cli/app_test.go
@@ -541,7 +541,6 @@ func appCallClientStream(t *testing.T, app *app, buf *bytes.Buffer) {
 	}
 
 	res := buf.Bytes()
-	fmt.Println(string(res))
 	root, err := ajson.Unmarshal(res)
 	if err != nil {
 		t.Errorf("error unmarshaling result json: %v", err)

--- a/cmd/grpc-client-cli/app_test.go
+++ b/cmd/grpc-client-cli/app_test.go
@@ -541,6 +541,7 @@ func appCallClientStream(t *testing.T, app *app, buf *bytes.Buffer) {
 	}
 
 	res := buf.Bytes()
+	fmt.Println(string(res))
 	root, err := ajson.Unmarshal(res)
 	if err != nil {
 		t.Errorf("error unmarshaling result json: %v", err)

--- a/cmd/grpc-client-cli/main.go
+++ b/cmd/grpc-client-cli/main.go
@@ -141,6 +141,11 @@ func main() {
 			Required: false,
 			Usage:    "host:port of the service",
 		},
+		&cli.BoolFlag{
+			Name:  "out-json-names",
+			Value: false,
+			Usage: "If true uses json_name properties/camel casing in message output",
+		},
 	}
 
 	app.Action = baseCmd
@@ -215,6 +220,7 @@ func runApp(c *cli.Context, opts *startOpts) (e error) {
 	opts.KeepaliveTime = c.Duration("keepalive-time")
 	opts.Keepalive = c.Bool("keepalive")
 	opts.MaxRecvMsgSize = c.Int("max-receive-message-size")
+	opts.OutJsonNames = c.Bool("out-json-names")
 
 	input := c.String("input")
 

--- a/internal/caller/servicecaller.go
+++ b/internal/caller/servicecaller.go
@@ -84,14 +84,16 @@ type ServiceCaller struct {
 	inMsgFormat  MsgFormat
 	outMsgFormat MsgFormat
 	fdescCache   *FileDescCache
+	outJsonNames bool
 }
 
-func NewServiceCaller(connFact *rpc.GrpcConnFactory, inMsgFormat, outMsgFormat MsgFormat, fdescCache *FileDescCache) *ServiceCaller {
+func NewServiceCaller(connFact *rpc.GrpcConnFactory, inMsgFormat, outMsgFormat MsgFormat, fdescCache *FileDescCache, outJsonNames bool) *ServiceCaller {
 	return &ServiceCaller{
 		connFact:     connFact,
 		inMsgFormat:  inMsgFormat,
 		outMsgFormat: outMsgFormat,
 		fdescCache:   fdescCache,
+		outJsonNames: outJsonNames,
 	}
 }
 
@@ -215,7 +217,7 @@ func (sc *ServiceCaller) marshalMessage(msg *dynamic.Message) ([]byte, error) {
 	return msg.MarshalJSONPB(&jsonpb.Marshaler{
 		EmitDefaults: true,
 		Indent:       "  ",
-		OrigName:     true,
+		OrigName:     !sc.outJsonNames,
 		AnyResolver:  &anyResolver{sc.fdescCache},
 	})
 }

--- a/internal/caller/servicecaller_test.go
+++ b/internal/caller/servicecaller_test.go
@@ -24,7 +24,7 @@ func TestMarshalJSON(t *testing.T) {
 	m.SetFieldByName("id", int32(1))
 	m.SetFieldByName("name", "test")
 
-	sc := NewServiceCaller(nil, JSON, JSON, nil)
+	sc := NewServiceCaller(nil, JSON, JSON, nil, false)
 	b, err := sc.marshalMessage(m)
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestMarshalJSON_AnyNotFound(t *testing.T) {
 	m.SetFieldByName("name", "test")
 	m.SetFieldByName("a", aValue)
 
-	sc := NewServiceCaller(nil, JSON, JSON, nil)
+	sc := NewServiceCaller(nil, JSON, JSON, nil, false)
 	b, err := sc.marshalMessage(m)
 	require.NoError(t, err)
 


### PR DESCRIPTION
this PR adds an optional `out-json-names` flag that will allow using camelCasing in the output