### PR TITLE
add --reflect-version to specify grpc reflect version

### DIFF
--- a/cmd/grpc-client-cli/app.go
+++ b/cmd/grpc-client-cli/app.go
@@ -33,17 +33,18 @@ type app struct {
 }
 
 type startOpts struct {
-	Service       string
-	Method        string
-	Discover      bool
-	Deadline      int
-	Verbose       bool
-	Target        string
-	IsInteractive bool
-	Authority     string
-	InFormat      caller.MsgFormat
-	OutFormat     caller.MsgFormat
-	OutJsonNames  bool
+	Service            string
+	Method             string
+	Discover           bool
+	Deadline           int
+	Verbose            bool
+	Target             string
+	IsInteractive      bool
+	Authority          string
+	InFormat           caller.MsgFormat
+	OutFormat          caller.MsgFormat
+	OutJsonNames       bool
+	GrpcReflectVersion caller.GrpcReflectVersion
 
 	// connection credentials
 	TLS      bool
@@ -98,7 +99,13 @@ func newApp(opts *startOpts) (*app, error) {
 	if len(opts.Protos) > 0 {
 		svc = caller.NewServiceMetadataProto(opts.Protos, opts.ProtoImports)
 	} else {
-		svc = caller.NewServiceMetaData(a.connFact, a.opts.Target, a.opts.Deadline, opts.ProtoImports)
+		svc = caller.NewServiceMetaData(&caller.ServiceMetaDataConfig{
+			ConnFact:       a.connFact,
+			Target:         a.opts.Target,
+			Deadline:       a.opts.Deadline,
+			ProtoImports:   a.opts.ProtoImports,
+			ReflectVersion: a.opts.GrpcReflectVersion,
+		})
 	}
 
 	ctx := rpc.WithStatsCtx(context.Background())

--- a/cmd/grpc-client-cli/main.go
+++ b/cmd/grpc-client-cli/main.go
@@ -148,6 +148,16 @@ func main() {
 			Value: false,
 			Usage: "If true uses json_name properties/camel casing in message output",
 		},
+		&cli.GenericFlag{
+			Name: "reflect-version",
+			Value: &cliext.EnumValue{
+				Enum:    []string{"v1alpha", "auto"},
+				Default: "v1alpha",
+			},
+			Usage: "Specify which grpc reflection version to use, v1alpha is the default as it's the most widely used version for now. " +
+				`"auto" option will try to determine the version automatically, it requires correctly functioning grpc server that returns Unimplemented error in case v1 or v1alpha are not supported. ` +
+				"After v1 release the default option will be changed.",
+		},
 	}
 
 	app.Action = baseCmd
@@ -223,6 +233,7 @@ func runApp(c *cli.Context, opts *startOpts) (e error) {
 	opts.Keepalive = c.Bool("keepalive")
 	opts.MaxRecvMsgSize = c.Int("max-receive-message-size")
 	opts.OutJsonNames = c.Bool("out-json-names")
+	opts.GrpcReflectVersion = parseReflectVersion(c.Generic("reflect-version"))
 
 	input := c.String("input")
 
@@ -317,4 +328,12 @@ func parseMsgFormat(val interface{}) caller.MsgFormat {
 	}
 
 	return caller.JSON
+}
+
+func parseReflectVersion(val interface{}) caller.GrpcReflectVersion {
+	if enum, ok := val.(*cliext.EnumValue); ok {
+		return caller.ParseGrpcReflectVersion(enum.String())
+	}
+
+	return caller.GrpcReflectV1Alpha
 }

--- a/internal/caller/servicecaller.go
+++ b/internal/caller/servicecaller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/vadimi/grpc-client-cli/internal/rpc"
@@ -39,9 +40,28 @@ func ParseMsgFormat(s string) MsgFormat {
 	return JSON
 }
 
+type GrpcReflectVersion int
+
+func ParseGrpcReflectVersion(s string) GrpcReflectVersion {
+	switch strings.ToLower(s) {
+	case "v1alpha":
+		return GrpcReflectV1Alpha
+	case "auto":
+		return GrpcReflectAuto
+	default:
+		return GrpcReflectV1Alpha
+	}
+}
+
 const (
 	JSON MsgFormat = iota
 	Text
+)
+
+const (
+	GrpcReflectV1Alpha GrpcReflectVersion = iota
+	// automatically determine which grpc reflection version to use
+	GrpcReflectAuto
 )
 
 type temporary interface {

--- a/internal/caller/servicemeta_test.go
+++ b/internal/caller/servicemeta_test.go
@@ -1,0 +1,56 @@
+package caller
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vadimi/grpc-client-cli/internal/rpc"
+	"google.golang.org/grpc"
+)
+
+func TestGrpcReflectVersions(t *testing.T) {
+	const reflectV1alphaMethod = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+	const reflectV1Method = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
+
+	tests := []struct {
+		name           string
+		expectedMethod string
+		version        GrpcReflectVersion
+	}{
+		{name: "v1alpha", version: GrpcReflectV1Alpha, expectedMethod: reflectV1alphaMethod},
+		{name: "auto", version: GrpcReflectAuto, expectedMethod: reflectV1Method},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lis, err := net.Listen("tcp", "localhost:0")
+			if err != nil {
+				t.Fatalf("failed to listen: %v", err)
+			}
+
+			unknownHandler := func(_ any, stream grpc.ServerStream) error {
+				m, ok := grpc.Method(stream.Context())
+				assert.True(t, ok)
+				assert.Equal(t, tt.expectedMethod, m, "wrong grpc reflect method called")
+				return nil
+			}
+
+			s := grpc.NewServer(grpc.UnknownServiceHandler(unknownHandler))
+			defer s.Stop()
+			go s.Serve(lis)
+
+			svc := NewServiceMetaData(&ServiceMetaDataConfig{
+				ConnFact:       rpc.NewGrpcConnFactory(),
+				Target:         lis.Addr().String(),
+				ReflectVersion: tt.version,
+				Deadline:       15,
+			})
+
+			_, err = svc.GetServiceMetaDataList(context.Background())
+			assert.ErrorIs(t, err, io.EOF)
+		})
+	}
+}


### PR DESCRIPTION
protoreflect library picks the right grpc reflection version automatically, but it doesn't work sometimes, so this PR makes v1alpha the default and adds `--reflect-version` param to configure it

fixes #56 