### PR TITLE
implement new proto resolver to support Any type unmarshal

### DIFF
--- a/internal/caller/protoresolver.go
+++ b/internal/caller/protoresolver.go
@@ -1,0 +1,89 @@
+package caller
+
+import (
+	"errors"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/builder"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+var customAnyDescr *desc.MessageDescriptor
+
+func init() {
+	md, err := builder.NewMessage("any").
+		AddField(builder.NewField("err", builder.FieldTypeString())).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	customAnyDescr = md
+}
+
+type protoResolver struct {
+	*dynamicpb.Types
+}
+
+func newResolver() *protoResolver {
+	return &protoResolver{dynamicpb.NewTypes(protoregistry.GlobalFiles)}
+}
+
+// FindMessageByURL is being called when Any @type needs to be resolved
+func (t *protoResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	mt, err := t.Types.FindMessageByURL(url)
+	if err != nil {
+		if errors.Is(err, protoregistry.NotFound) {
+			msg := dynamicpb.NewMessage(customAnyDescr.UnwrapMessage())
+			return &unknownMsgType{msg}, nil
+		}
+		return mt, err
+	}
+	return mt, nil
+}
+
+// unknownMsgType represents protoreflect.MessageType of unknownMsg
+type unknownMsgType struct {
+	m *dynamicpb.Message
+}
+
+func (u *unknownMsgType) New() protoreflect.Message {
+	return &unknownMsg{u.m}
+}
+
+func (u *unknownMsgType) Zero() protoreflect.Message {
+	return &unknownMsg{u.m}
+}
+
+func (u *unknownMsgType) Descriptor() protoreflect.MessageDescriptor {
+	return u.m.Descriptor()
+}
+
+// unknownMsg is used when underlying type of google.protobuf.Any type cannot be resolved
+type unknownMsg struct {
+	*dynamicpb.Message
+}
+
+func (m *unknownMsg) Interface() protoreflect.ProtoMessage {
+	return m
+}
+
+func (m *unknownMsg) ProtoReflect() protoreflect.Message {
+	return m
+}
+
+func (a *unknownMsg) ProtoMethods() *protoiface.Methods {
+	return &protoiface.Methods{
+		Unmarshal: func(in protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+			if msg, ok := in.Message.(*unknownMsg); ok {
+				msg.Set(
+					msg.Descriptor().Fields().ByName("err"),
+					protoreflect.ValueOfString("type not found"))
+			}
+			return protoiface.UnmarshalOutput{}, nil
+		},
+	}
+}

--- a/internal/caller/protoresolver_test.go
+++ b/internal/caller/protoresolver_test.go
@@ -1,0 +1,50 @@
+package caller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+func TestResolver_WellKnown(t *testing.T) {
+	r := newResolver()
+
+	typeName := "google.protobuf.StringValue"
+	m, err := r.FindMessageByName(protoreflect.FullName(typeName))
+	require.NoError(t, err)
+
+	fullName := string(m.Descriptor().FullName())
+	require.Equal(t, typeName, fullName)
+}
+
+func TestResolver_LoadedFiles(t *testing.T) {
+	sml := NewServiceMetadataProto([]string{"../../testdata/test.proto"}, nil)
+	_, err := sml.GetServiceMetaDataList(context.Background())
+	require.NoError(t, err)
+
+	r := newResolver()
+
+	userType := "grpc_client_cli.testing.User"
+
+	typeURL := "type.googleapis.com/" + userType
+	m, err := r.FindMessageByURL(typeURL)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	require.Equal(t, userType, string(m.Descriptor().FullName()))
+}
+
+func TestResolver_UnmarshalEmpty(t *testing.T) {
+	r := newResolver()
+	m, err := r.FindMessageByURL("testing.protobuf.DoesNotExist")
+	require.NoError(t, err)
+	require.Equal(t, "any", string(m.Descriptor().FullName()))
+	msg := dynamicpb.NewMessage(m.Descriptor())
+	res, err := protojson.Marshal(msg)
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(res))
+}

--- a/internal/caller/servicemetabase.go
+++ b/internal/caller/servicemetabase.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jhump/protoreflect/desc"
+	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 type ServiceMetaData interface {
@@ -44,4 +45,14 @@ func (s serviceMetaBase) GetAdditionalFiles(protoImports []string) ([]*desc.File
 		return nil, fmt.Errorf("error parsing additional proto files: %w", err)
 	}
 	return fileDesc, nil
+}
+
+func RegisterFiles(fds ...*desc.FileDescriptor) {
+	for _, fd := range fds {
+		protoFile := fd.UnwrapFile()
+		_, err := protoregistry.GlobalFiles.FindFileByPath(protoFile.Path())
+		if errors.Is(err, protoregistry.NotFound) {
+			protoregistry.GlobalFiles.RegisterFile(protoFile)
+		}
+	}
 }


### PR DESCRIPTION
this is needed to support unknown `google.protobuf.Any` unmarshal in the new version of protobuf