### PR TITLE
Update go version to 1.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vadimi/grpc-client-cli
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Avoids 3 CVEs related to stack exhaustion:
https://avd.aquasec.com/nvd/2024/cve-2024-34156/
https://avd.aquasec.com/nvd/2024/cve-2024-34158/
https://avd.aquasec.com/nvd/2024/cve-2024-34155/